### PR TITLE
Fix architecture issue with M1 ect Macs  

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The helper file contained within this repository (`vdat.sh`) aims to provide acc
 3. Install Docker
   - [macOS](https://docs.docker.com/desktop/install/mac-install/)
   - [Linux](https://docs.docker.com/engine/install/)
-4. Open a terminal and pull the VDAT Docker image: `docker pull ghcr.io/trackyverse/vdat` 
+4. Open a terminal and pull the VDAT Docker image: `docker pull ghcr.io/trackyverse/vdat:latest` 
 5. In the terminal, navigate to the directory where you downloaded the Fathom Connect installer and `vdat.sh` script.
 6. Make the helper script executable: `chmod +x vdat.sh`
 7. Run the helper script with the Fathom Connect installer as an argument: `./vdat.sh Fathom_Installer.msi`. This will extract `vdat.exe` from the installer and place it in the same directory.

--- a/vdat.sh
+++ b/vdat.sh
@@ -75,6 +75,16 @@ else
     THINGS_TO_MOUNT="-v $(readlink -f $2):/VDAT/$(basename $2)"
   fi
   
+  # we need to ID host arch to get the correct build 
+  HOST_ARCH=$(uname -m)
+  # Default docker platform option empty
+  DOCKER_PLATFORM=""
+  
+  # If host is arm64 (M1, ect MACs), force amd64 for vdat since vdat is 86-64
+  if [ "$HOST_ARCH" = "aarch64" ] || [ "$HOST_ARCH" = "arm64" ]; then
+  DOCKER_PLATFORM="--platform linux/amd64"
+fi
+
   # Run the vdat.exe command in the container with wine
   #   --rm -> remove container after run
   #   -v ${VDAT_FULL_PATH}:/VDAT/vdat.exe -> mount vdat.exe to the container

--- a/vdat.sh
+++ b/vdat.sh
@@ -91,7 +91,9 @@ fi
   #   $THINGS_TO_MOUNT -> mount any input/output files or directories if needed
   #   ghcr.io/trackyverse/vdat sh -c "$VDAT_CMD" -> run the vdat command in a shell
   #      within the container
+  # add in docker platform 
   docker run --rm \
+   $DOCKER_PLATFORM \
     -v ${VDAT_FULL_PATH}:/VDAT/vdat.exe \
     $THINGS_TO_MOUNT \
     ghcr.io/trackyverse/vdat sh -c "$VDAT_CMD"


### PR DESCRIPTION
Right now because alpine is only able to run wine in 64 bit and M1 ect. Macs are aarch64 this fails because vdat is 86-64 built. 

To fix this we need to run docker on `--platform linux/amd64`. I have updated the bash file to first detect the host arch then if it is `aarch64` it will run docker using `--platform linux/amd64`. Which allows vdat to run. 

